### PR TITLE
fixed query not catching MeshData and MeshResource

### DIFF
--- a/examples/custom_mesh_test.rs
+++ b/examples/custom_mesh_test.rs
@@ -99,10 +99,7 @@ fn setup(
 
     let handle = meshes.add(mesh);
 
-    commands.spawn().insert((
-        data, 
-        MeshResource { mesh: handle.clone()}
-    ));
+    commands.spawn().insert_bundle((data, MeshResource { mesh: handle.clone()}));
 
     // plane
     commands.spawn_bundle(PbrBundle {


### PR DESCRIPTION
I asked on Bevy Discord for help, and it turns out that to register a tuple of components, we must use `insert_bundle`. That fixes the issue!