### PR TITLE
Add support for rectangular fonts

### DIFF
--- a/examples/font_change.rs
+++ b/examples/font_change.rs
@@ -78,7 +78,7 @@ fn change_font(
             let new_font_name = BUILT_IN_FONTS[font_index.0].name;
 
             let new_font = fonts.get(new_font_name);
-            projection.pixels_per_tile = new_font.pixels_per_unit();
+            projection.pixels_per_tile = new_font.pixels_per_unit().y;
             font.change_font(new_font_name);
             draw_title(&mut term, new_font_name);
         }

--- a/src/renderer/font.rs
+++ b/src/renderer/font.rs
@@ -50,7 +50,7 @@ pub struct TerminalFont {
     /// The color on the texture that should be treated as the background
     clip_color: Color,
     tex_handle: Handle<Texture>,
-    pixels_per_unit: u32,
+    pixels_per_unit: UVec2,
     //tile_count: UVec2,
 }
 impl Default for TerminalFont {
@@ -111,7 +111,7 @@ impl TerminalFont {
     }
 
     /// How many vertical pixels for a single character.
-    pub fn pixels_per_unit(&self) -> u32 {
+    pub fn pixels_per_unit(&self) -> UVec2 {
         self.pixels_per_unit
     }
 
@@ -130,7 +130,7 @@ impl TerminalFont {
         let texture = textures.get(tex_handle.clone_weak()).unwrap();
         let tex_size = UVec2::new(texture.size.width, texture.size.height);
         let tile_count = UVec2::new(16, 16);
-        let pixels_per_tile = (tex_size / tile_count).y;
+        let pixels_per_tile = tex_size / tile_count;
 
         TerminalFont {
             name: String::from(name),


### PR DESCRIPTION
This turned out to be very simple to implement. I've tested that all existing examples still work as expected as well as testing this version of bevy_ascii_terminal against my project. I think it's probably worth adding one or two examples showing overlapping terminals with transparency as well as rectangular font use. Do you think that should be done in the context of this PR? Also, would it be a good idea to add at least rectangular font to the embedded fonts?