### PR TITLE
Upgrade bevy to 0.18

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,11 @@ version = "0.18.1"
 
 [dependencies]
 enum-ordinalize = "4.3.0"
-thiserror = "1.0.56"
+thiserror = "2"
 flate2 = "1.0"
 byteorder = "1"
 sark_grids = "0.7"
-bevy_platform = "0.17"
+bevy_platform = "0.18"
 anyhow = "1.0.100"
 nom = "8.0.0"
 
@@ -25,12 +25,12 @@ fastnoise-lite = "1.1.1"
 rand = "0.8.4"
 
 [dependencies.bevy]
-version = "0.17"
+version = "0.18"
 default-features = false
 features = ["std", "png", "bevy_render", "bevy_asset", "bevy_sprite", "bevy_sprite_render", "bevy_window", "bevy_color"]
 
 [dev-dependencies.bevy]
-version = "0.17"
+version = "0.18"
 default-features = false
 features = ["bevy_winit"]
 


### PR DESCRIPTION
This PR upgrades `bevy` to 0.18 and `thiserror` to 2.x.

Tests pass and examples seem to run.